### PR TITLE
Factor out CLI

### DIFF
--- a/clonepool/__main__.py
+++ b/clonepool/__main__.py
@@ -5,7 +5,7 @@ https://kushaldas.in/posts/building-command-line-tools-in-python-with-click.html
 '''
 import click
 
-from clonepool.clonepool import layout, simulate, resolve
+from clonepool.clonepool import layout_cli, simulate_cli, resolve_cli
 
 # Do not sort the command list alphabetically, but use order in which commands
 # are added.
@@ -15,6 +15,6 @@ class UnsortedGroup(click.Group):
 
 cli = UnsortedGroup()
 
-cli.add_command(layout)
-cli.add_command(simulate)
-cli.add_command(resolve)
+cli.add_command(layout_cli)
+cli.add_command(simulate_cli)
+cli.add_command(resolve_cli)

--- a/clonepool/__main__.py
+++ b/clonepool/__main__.py
@@ -5,7 +5,7 @@ https://kushaldas.in/posts/building-command-line-tools-in-python-with-click.html
 '''
 import click
 
-from clonepool.clonepool import layout_cli, simulate_cli, resolve_cli
+from clonepool.cli import layout_cli, simulate_cli, resolve_cli
 
 # Do not sort the command list alphabetically, but use order in which commands
 # are added.

--- a/clonepool/__main__.py
+++ b/clonepool/__main__.py
@@ -1,20 +1,8 @@
-'''
-CLI
+# __main__.py
 
-https://kushaldas.in/posts/building-command-line-tools-in-python-with-click.html
-'''
-import click
+from clonepool.cli import cli
 
-from clonepool.cli import layout_cli, simulate_cli, resolve_cli
 
-# Do not sort the command list alphabetically, but use order in which commands
-# are added.
-class UnsortedGroup(click.Group):
-    def list_commands(self, ctx):
-        return self.commands
-
-cli = UnsortedGroup()
-
-cli.add_command(layout_cli)
-cli.add_command(simulate_cli)
-cli.add_command(resolve_cli)
+# Make package executable via `python -m <package_name>`.
+if __name__ == '__main__':
+    cli()

--- a/clonepool/cli.py
+++ b/clonepool/cli.py
@@ -1,0 +1,69 @@
+# cli.py
+
+import click
+
+from clonepool.clonepool import layout, simulate, resolve
+
+@click.command('layout')
+@click.option(
+    '-n', '--samples', required=False, type=int,
+    help='Number of samples')
+@click.option(
+    '-P', '--pool-size', required=True, type=int,
+    help='How many samples go into each pool')
+@click.option(
+    '-r', '--replicates', default=2, type=int,
+    help='Number of replicates per sample [2]')
+@click.option(
+    '-w', '--pool-count', default=94, type=int,
+    help='Number of pools (wells) [94]')
+@click.argument(
+    'layout_file', required=False, default='-', type=click.File('w'))
+def layout_cli(pool_size, pool_count, replicates, samples, layout_file):
+    '''
+    Generate pool layout. This assigns all samples to their respecitve pools.
+
+    Writes to STDOUT or the given layout file.
+    '''
+    layout(pool_size, pool_count, replicates, samples, layout_file)
+
+
+@click.command('simulate')
+@click.option(
+    '-l', '--layout', required=True, type=click.File('r'),
+    help='Path to input file containing pool layout')
+@click.option(
+    '-p', '--prevalence', default=0.05, type=click.FloatRange(0, 1),
+    help='Sample prevalence used for simulation [0.05]')
+@click.option(
+    '-P', '--false-positives', default=0, type=click.FloatRange(0, 1),
+    help='Fraction of false-positive pools [0]')
+@click.option(
+    '-N', '--false-negatives', default=0, type=click.FloatRange(0, 1),
+    help='Fraction of false-negative pools [0]')
+@click.argument(
+    'out_layout_file', required=False, default='-', type=click.File('w'))
+def simulate_cli(layout, prevalence, false_positives, false_negatives, out_layout_file):
+    '''
+    For a given pool layout, simulate a test run. Uses a defined sample
+    prevalence to determine a random set of positive samples and,
+    successively, flags all pools as positive containing any of these samples.
+
+    Writes to STDOUT or the given layout file.
+    '''
+    simulate(layout, prevalence, false_positives, false_negatives, out_layout_file)
+
+
+@click.command('resolve')
+@click.option(
+    '--layout', '-l', required=True, type=click.File('r'),
+    help='Path to layout file containing +/- pool results')
+@click.argument(
+    'sample_results_file', required=False, default='-', type=click.File('w'))
+def resolve_cli(layout, sample_results_file):
+    '''
+    Resolve sample status from pool results. As this is not always
+    possible, some samples may remain in an uncertain state.
+    Writes to STDOUT or the given results file.
+    '''
+    resolve(layout, sample_results_file)

--- a/clonepool/cli.py
+++ b/clonepool/cli.py
@@ -67,3 +67,18 @@ def resolve_cli(layout, sample_results_file):
     Writes to STDOUT or the given results file.
     '''
     resolve(layout, sample_results_file)
+
+
+##### Set up command line interface commands.
+
+# Do not sort the command list alphabetically, but use order in which commands
+# are added.
+class UnsortedGroup(click.Group):
+    def list_commands(self, ctx):
+        return self.commands
+
+cli = UnsortedGroup()
+
+cli.add_command(layout_cli)
+cli.add_command(simulate_cli)
+cli.add_command(resolve_cli)

--- a/clonepool/clonepool.py
+++ b/clonepool/clonepool.py
@@ -18,7 +18,7 @@ from clonepool.utils import (
 )
 
 
-@click.command()
+@click.command('layout')
 @click.option(
     '-n', '--samples', required=False, type=int,
     help='Number of samples')
@@ -33,12 +33,16 @@ from clonepool.utils import (
     help='Number of pools (wells) [94]')
 @click.argument(
     'layout_file', required=False, default='-', type=click.File('w'))
-def layout(pool_size, pool_count, replicates, samples, layout_file):
+def layout_cli(pool_size, pool_count, replicates, samples, layout_file):
     '''
     Generate pool layout. This assigns all samples to their respecitve pools.
 
     Writes to STDOUT or the given layout file.
     '''
+    layout(pool_size, pool_count, replicates, samples, layout_file)
+
+
+def layout(pool_size, pool_count, replicates, samples, layout_file):
     # Check if sample count is valid.
     max_sample_support = int(np.floor((pool_size * pool_count) / replicates))
     if not samples:
@@ -53,7 +57,7 @@ def layout(pool_size, pool_count, replicates, samples, layout_file):
     write_layout_file(layout_file, pool_log)
 
 
-@click.command()
+@click.command('simulate')
 @click.option(
     '-l', '--layout', required=True, type=click.File('r'),
     help='Path to input file containing pool layout')
@@ -68,7 +72,7 @@ def layout(pool_size, pool_count, replicates, samples, layout_file):
     help='Fraction of false-negative pools [0]')
 @click.argument(
     'out_layout_file', required=False, default='-', type=click.File('w'))
-def simulate(layout, prevalence, false_positives, false_negatives, out_layout_file):
+def simulate_cli(layout, prevalence, false_positives, false_negatives, out_layout_file):
     '''
     For a given pool layout, simulate a test run. Uses a defined sample
     prevalence to determine a random set of positive samples and,
@@ -76,6 +80,10 @@ def simulate(layout, prevalence, false_positives, false_negatives, out_layout_fi
 
     Writes to STDOUT or the given layout file.
     '''
+    simulate(layout, prevalence, false_positives, false_negatives, out_layout_file)
+
+
+def simulate(layout, prevalence, false_positives, false_negatives, out_layout_file):
     # Read existing pool layout, discard old positive pools / samples if any.
     pool_log, _, _ = read_layout_file(layout)
 
@@ -92,18 +100,22 @@ def simulate(layout, prevalence, false_positives, false_negatives, out_layout_fi
             out_layout_file, pool_log, positive_pools, positive_samples)
 
 
-@click.command()
+@click.command('resolve')
 @click.option(
     '--layout', '-l', required=True, type=click.File('r'),
     help='Path to layout file containing +/- pool results')
 @click.argument(
     'sample_results_file', required=False, default='-', type=click.File('w'))
-def resolve(layout, sample_results_file):
+def resolve_cli(layout, sample_results_file):
     '''
     Resolve sample status from pool results. As this is not always
     possible, some samples may remain in an uncertain state.
     Writes to STDOUT or the given results file.
     '''
+    resolve(layout, sample_results_file)
+
+
+def resolve(layout, sample_results_file):
     # Read layout file including pool test results and, possibly, a ground
     # truth set of positive samples
     pool_log, pos_pools, true_pos_samples = read_layout_file(layout)

--- a/clonepool/clonepool.py
+++ b/clonepool/clonepool.py
@@ -3,9 +3,7 @@
 from collections import defaultdict
 import sys
 
-import click
 import numpy as np
-
 from clonepool.utils import (
     set_up_pools,
     simulate_pools,
@@ -16,30 +14,6 @@ from clonepool.utils import (
     read_layout_file,
     write_layout_file,
 )
-
-
-@click.command('layout')
-@click.option(
-    '-n', '--samples', required=False, type=int,
-    help='Number of samples')
-@click.option(
-    '-P', '--pool-size', required=True, type=int,
-    help='How many samples go into each pool')
-@click.option(
-    '-r', '--replicates', default=2, type=int,
-    help='Number of replicates per sample [2]')
-@click.option(
-    '-w', '--pool-count', default=94, type=int,
-    help='Number of pools (wells) [94]')
-@click.argument(
-    'layout_file', required=False, default='-', type=click.File('w'))
-def layout_cli(pool_size, pool_count, replicates, samples, layout_file):
-    '''
-    Generate pool layout. This assigns all samples to their respecitve pools.
-
-    Writes to STDOUT or the given layout file.
-    '''
-    layout(pool_size, pool_count, replicates, samples, layout_file)
 
 
 def layout(pool_size, pool_count, replicates, samples, layout_file):
@@ -57,32 +31,6 @@ def layout(pool_size, pool_count, replicates, samples, layout_file):
     write_layout_file(layout_file, pool_log)
 
 
-@click.command('simulate')
-@click.option(
-    '-l', '--layout', required=True, type=click.File('r'),
-    help='Path to input file containing pool layout')
-@click.option(
-    '-p', '--prevalence', default=0.05, type=click.FloatRange(0, 1),
-    help='Sample prevalence used for simulation [0.05]')
-@click.option(
-    '-P', '--false-positives', default=0, type=click.FloatRange(0, 1),
-    help='Fraction of false-positive pools [0]')
-@click.option(
-    '-N', '--false-negatives', default=0, type=click.FloatRange(0, 1),
-    help='Fraction of false-negative pools [0]')
-@click.argument(
-    'out_layout_file', required=False, default='-', type=click.File('w'))
-def simulate_cli(layout, prevalence, false_positives, false_negatives, out_layout_file):
-    '''
-    For a given pool layout, simulate a test run. Uses a defined sample
-    prevalence to determine a random set of positive samples and,
-    successively, flags all pools as positive containing any of these samples.
-
-    Writes to STDOUT or the given layout file.
-    '''
-    simulate(layout, prevalence, false_positives, false_negatives, out_layout_file)
-
-
 def simulate(layout, prevalence, false_positives, false_negatives, out_layout_file):
     # Read existing pool layout, discard old positive pools / samples if any.
     pool_log, _, _ = read_layout_file(layout)
@@ -98,21 +46,6 @@ def simulate(layout, prevalence, false_positives, false_negatives, out_layout_fi
     # Write layout including new pool results.
     write_layout_file(
             out_layout_file, pool_log, positive_pools, positive_samples)
-
-
-@click.command('resolve')
-@click.option(
-    '--layout', '-l', required=True, type=click.File('r'),
-    help='Path to layout file containing +/- pool results')
-@click.argument(
-    'sample_results_file', required=False, default='-', type=click.File('w'))
-def resolve_cli(layout, sample_results_file):
-    '''
-    Resolve sample status from pool results. As this is not always
-    possible, some samples may remain in an uncertain state.
-    Writes to STDOUT or the given results file.
-    '''
-    resolve(layout, sample_results_file)
 
 
 def resolve(layout, sample_results_file):
@@ -138,5 +71,3 @@ def resolve(layout, sample_results_file):
     for sample, state in sorted(sample_state.items()):
         state_symbol = '+' if state == +1 else '-' if state == -1 else 'NA'
         sample_results_file.write(f'{sample}\t{state_symbol}\n')
-
-# EOF


### PR DESCRIPTION
I separated the CLI code from our workhorses `layout()`, `simulate()` and `resolve()` out of `clonepool.py` into its own `cli.py`. This makes the code more readable (separates concerns) and also allows to `import clonepool` in other python code and use its functionality there. 